### PR TITLE
Enable Contrast application security scan

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -5,9 +5,9 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -15,15 +15,28 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: ['8', '11', '17']
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK ${{matrix.java}}
-        uses: actions/setup-java@v2
-        with:
-          java-version: ${{matrix.java}}
-          distribution: 'adopt'
-          cache: maven
-      - name: Build with Maven Wrapper
-        run: ./mvnw -B package
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{matrix.java}}
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{matrix.java}}
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven Wrapper
+      run: ./mvnw -B package
+    - name: Assess and Scan with Contrast
+      run: ./mvnw verify -Pcontrast-assess
+      env:
+        CONTRAST_USERNAME: ${{ secrets.CONTRAST_USERNAME }}
+        CONTRAST_API_KEY: ${{ secrets.CONTRAST_API_KEY }}
+        CONTRAST_SERVICE_KEY: ${{ secrets.CONTRAST_SERVICE_KEY }}
+        CONTRAST_URL: ${{ secrets.CONTRAST_URL }}
+        CONTRAST_ORG_ID: ${{ secrets.CONTRAST_ORG_ID }}
+        CONTRAST_APP_NAME: ${{ github.repository }} # repo_owner/repo_name
+        CONTRAST_SERVER_NAME: github
+        CONTRAST_COMMIT_HASH: ${{ github.sha }}
+        CONTRAST_REPOSITORY: "${{ github.repositoryUrl }}"
+        CONTRAST_MIN_SEVERITY: Critical

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,21 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>com.contrastsecurity</groupId>
+        <artifactId>contrast-maven-plugin</artifactId>
+        <version>2.13.2</version>
+        <configuration>
+          <username>${env.CONTRAST_USERNAME}</username>
+          <apiKey>${env.CONTRAST_API_KEY}</apiKey>
+          <serviceKey>${env.CONTRAST_SERVICE_KEY}</serviceKey>
+          <url>${env.CONTRAST_URL}</url>
+          <orgUuid>${env.CONTRAST_ORG_ID}</orgUuid>
+          <appName>${env.CONTRAST_APP_NAME}</appName>
+          <applicationSessionMetadata>commitHash=${env.CONTRAST_COMMIT_HASH},repository=${env.CONTRAST_REPOSITORY}</applicationSessionMetadata>
+          <minSeverity>${env.CONTRAST_MIN_SEVERITY}</minSeverity>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -385,6 +400,31 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>contrast-assess</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.contrastsecurity</groupId>
+            <artifactId>contrast-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install</id>
+                <goals>
+                  <goal>install</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
Changes to enable Contrast SAST and IAST scans for this repo.

Additional documentation can be found [here](https://docs.contrastsecurity.com/en/get-started.html).

Results from the Contrast scans will be available in your [Contrast portal](https://eval.contrastsecurity.com/Contrast/static/ng/index.html#/53446870-2d72-4afe-a540-6855b864ba22/dashboard).